### PR TITLE
Cleans up and fixes weighted_shuffle for issue #1

### DIFF
--- a/blur/rand.py
+++ b/blur/rand.py
@@ -447,7 +447,7 @@ def weighted_shuffle(weights):
     # shuffles list to remove bias when sorting
     random.shuffle(weighted_absolute_positions)
     # sorts list in descending weights
-    weighted_absolute_positions.sort(key=lambda (_, __, w): w, reverse=True)
+    weighted_absolute_positions.sort(key=lambda tup: tup[2], reverse=True)
 
     # at this point, we have a fair list of descending weights, and can
     # iterate through it and place the values close to where they requested


### PR DESCRIPTION
This fixes issue #1 

Running the same code in the issue now gives:

``` python
{'a': [2, 2, 2, 0, 1, 0, 1, 0, 1, 4],
 'b': [3, 3, 3, 3, 3, 3, 3, 3, 3, 3], 
 'e': [4, 1, 4, 1, 0, 1, 0, 1, 0, 2],
 'd': [0, 0, 1, 2, 4, 2, 4, 2, 2, 1], 
 'c': [1, 4, 0, 4, 2, 4, 2, 4, 4, 0]}
```
