### PR TITLE
Replace weighted_shuffle() with weighted_order()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # blur
-#### 0.2dev
+#### 0.2dev (unstable)
 
-[![Build Status](https://travis-ci.org/ajyoon/blur.svg?branch=master)](https://travis-ci.org/ajyoon/blur)  [![Documentation Status](https://readthedocs.org/projects/blur/badge/?version=latest)](http://blur.readthedocs.io/en/latest/?badge=latest)
+[![Build Status](https://travis-ci.org/ajyoon/blur.svg?branch=0.2dev)](https://travis-ci.org/ajyoon/blur)  [![Documentation Status](https://readthedocs.org/projects/blur/badge/?version=latest)](http://blur.readthedocs.io/en/latest/?badge=latest)
 
 blur is a suite of tools for Python to help make using chance operations in
 algorithmic art easier.

--- a/blur/rand.py
+++ b/blur/rand.py
@@ -406,9 +406,6 @@ def weighted_order(weights):
         list: the newly ordered list
     """
     remaining_items = weights[:]
-    # Sort remaining_items in decreasing order of weights to make item removal
-    # in the while loop more predictable when multiple items have the same
-    # out come value
     remaining_items.sort(key=lambda weight: weight[1], reverse=True)
     output_list = []
     while remaining_items:


### PR DESCRIPTION
Follow up to [Issue 1](https://github.com/ajyoon/blur/issues/1) and commit [849f874](https://github.com/ajyoon/blur/commit/849f874c461e951116cc7bac790321ba3d09019d). The specification of `weighted_shuffle()` was not clear enough, and its use case was unclear.

Docstring of the new function:

``` python
def weighted_order(weights):
    """
    Non-uniformally order a list according to weighted priorities.

    ``weights`` is a list of tuples of the form ``(item, priority)`` of
    types ``(Any, float or int)``. The output list is constructed by repeatedly
    calling ``weighted_choice()`` on the weights, adding items to the end of
    the list as the are picked.

    Higher value weights will have a higher chance of appearing near the
    beginning of the output list.

    A list of all uniform weights is equivalent to calling ``random.shuffle()``
    on the list of values.

    Args:
        weights (list[(Any, float or int)]):

    Returns:
        list: the newly ordered list
    """
```
